### PR TITLE
Fix "Unable to locate config_filename ~/.eskbcli"

### DIFF
--- a/src/elasticsearch_kibana_cli/cli/click_cli.py
+++ b/src/elasticsearch_kibana_cli/cli/click_cli.py
@@ -12,7 +12,7 @@ from elasticsearch_kibana_cli.utils.output import output_handler
 from elasticsearch_kibana_cli.ElasticsearchKibanaInterface import ElasticsearchKibanaInterface
 
 
-config_file_default = '~/.eskbcli'
+config_file_default = os.path.expanduser('~/.eskbcli')
 elasticsearch_kibana_interface = None
 
 


### PR DESCRIPTION
```
> python3
Python 3.8.10 (default, Jun  2 2021, 10:49:15)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.path.isfile('~/.eskbcli')
False
>>> os.path.expanduser('~/.eskbcli')
'/home/kolia/.eskbcli'
>>> os.path.isfile(os.path.expanduser('~/.eskbcli'))
True
```